### PR TITLE
[fix]:exp`number > null` is always false issue

### DIFF
--- a/Revit2GLTF/glTF/glTFExportContext.cs
+++ b/Revit2GLTF/glTF/glTFExportContext.cs
@@ -673,6 +673,12 @@ namespace Revit2Gltf.glTF
                 currentGeometry.indexBuffer.Add(index2);
                 currentGeometry.indexBuffer.Add(index3);
 
+
+                if (!currentGeometry.indexMax.HasValue)
+                {
+                    currentGeometry.indexMax = 0;
+                }
+
                 if (index1 > currentGeometry.indexMax)
                 {
                     currentGeometry.indexMax = index1;


### PR DESCRIPTION
When program process into OnPolymesh fucntion first time , 
the `currentGeometry.indexMax` is not init, it is Null 
when exec `index1 > currentGeometry.indexMax` is always false,

when rvt model big enough it will effect `addIndexsBufferViewAndAccessor` function code -> ` if (bufferData.indexMax > 65535)`

some indices accessor will miss and error.
